### PR TITLE
[plock-1]: add settings file

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,64 @@ Also [system tray icons require some extras](https://tauri.app/v1/guides/feature
 
 **Windows** (untested), you'll need to swap out Ollama for something else, as it doesn't support windows yet.
 
+## Settings
+
+There is a `settings.json` file which you can edit to change shortcuts, the model, 
+prompts, whether to use shell scripts and what they are, and other settings.
+
+On mac, It's at `~/Library/Application Support/today.jason.plock/settings.json`.
+
+On linux, I think it's `~/$XDG_DATA_HOME/today.jason.plock/settings.json`.
+
+Windows, I think it's `~\AppData\Local\today.jason.plock\settings.json`
+
+Correct me if any of these are wrong.
+
+<details>
+  <summary>Example</summary>
+
+```json
+{
+  "environment": {},
+  "ollama": {
+    "enabled": true,
+    "ollama_model": "openhermes2.5-mistral"
+  },
+  "custom_commands": {
+    "index": 0,
+    "custom_commands": [
+      {
+        "name": "gpt",
+        "command": [
+          "bash",
+          "/Users/jason/workspace/plock/scripts/gpt.sh"
+        ]
+      }
+    ]
+  },
+  "custom_prompts": {
+    "basic_index": 0,
+    "with_context_index": 1,
+    "custom_prompts": [
+      {
+        "name": "default basic",
+        "prompt": "Say hello, then {}"
+      },
+      {
+        "name": "default with context",
+        "prompt": "I will ask you to do something. Below is some extra context to help do what I ask. --------- {} --------- Given the above context, please, {}. DO NOT OUTPUT ANYTHING ELSE."
+      }
+    ]
+  },
+  "shortcuts": {
+    "basic": "CmdOrControl+Shift+.",
+    "with_context": "CmdOrControl+Shift+/"
+  }
+}
+```
+</details>
+
+
 ## Building Plock
 If you don't have apple silicon or don't want to blindly trust binaries (you shouldn't), here's how you can build it yourself!
 

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2628,6 +2628,7 @@ dependencies = [
  "arboard",
  "async-stream",
  "enigo",
+ "lazy_static",
  "ollama-rs",
  "rdev",
  "rusty-tesseract",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -13,7 +13,7 @@ edition = "2021"
 tauri-build = { version = "1.5", features = [] }
 
 [dependencies]
-tauri = { version = "1.5", features = [ "clipboard-all", "global-shortcut-all",
+tauri = { version = "1.5", features = [ "fs-all", "clipboard-all", "global-shortcut-all",
   "shell-open", "system-tray"
 ] }
 
@@ -26,6 +26,7 @@ async-stream = "0.3.0"
 rdev = { git = "https://github.com/fufesou/rdev" }
 enigo = "0.2.0-rc2"
 arboard = "3.3.0"
+lazy_static = "1.4.0"
 
 # OCR feature dependencies
 screenshots = { version = "0.8.6", optional = true }

--- a/src-tauri/src/generator.rs
+++ b/src-tauri/src/generator.rs
@@ -5,8 +5,7 @@ use std::process::Stdio;
 use tokio::io::{AsyncReadExt, BufReader};
 use tokio::process::Command;
 use tokio_stream::{Stream, StreamExt};
-
-const MODEL: &str = "openhermes2.5-mistral";
+use crate::settings::SETTINGS;
 
 pub enum TextGeneratorType {
     OllamaGenerator,
@@ -17,7 +16,8 @@ impl TextGeneratorType {
     pub(crate) async fn generate(&self, context: String) -> Pin<Box<dyn Stream<Item = String>>> {
         match self {
             TextGeneratorType::OllamaGenerator => {
-                let request = GenerationRequest::new(MODEL.to_string(), context);
+                let model = { SETTINGS.lock().unwrap().ollama.ollama_model.clone() };
+                let request = GenerationRequest::new(model, context);
                 Box::pin(async_stream::stream! {
                     let ollama = Ollama::default();
                     let mut stream = ollama.generate_stream(request).await.unwrap();
@@ -30,8 +30,10 @@ impl TextGeneratorType {
                 })
             }
             TextGeneratorType::ShellScriptGenerator => {
-                let child = Command::new("bash")
-                    .arg("/Users/jason/workspace/plock/scripts/gpt.sh")
+                let custom_command = { SETTINGS.lock().unwrap().custom_command.clone() };
+                // make child from custom_command
+                let child = Command::new(&custom_command[0])
+                    .args(&custom_command[1..])
                     .arg(&context)
                     .stdout(Stdio::piped())
                     .spawn()

--- a/src-tauri/src/generator.rs
+++ b/src-tauri/src/generator.rs
@@ -30,7 +30,12 @@ impl TextGeneratorType {
                 })
             }
             TextGeneratorType::ShellScriptGenerator => {
-                let custom_command = { SETTINGS.lock().unwrap().custom_command.clone() };
+                let custom_command = {
+                    let settings = SETTINGS.lock().unwrap();
+                    settings.custom_commands.custom_commands[
+                        settings.custom_commands.index
+                    ].command.clone()
+                };
                 // make child from custom_command
                 let child = Command::new(&custom_command[0])
                     .args(&custom_command[1..])

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -8,25 +8,24 @@ use std::collections::HashSet;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Mutex;
 use std::{sync::Arc, thread};
-use tauri::{
-    ActivationPolicy, AppHandle, CustomMenuItem, GlobalShortcutManager, SystemTray,
-    SystemTrayEvent, SystemTrayMenu, WindowEvent,
-};
+use tauri::{ActivationPolicy, AppHandle, CustomMenuItem, GlobalShortcutManager, Manager, SystemTray, SystemTrayEvent, SystemTrayMenu, SystemTrayMenuItem, WindowEvent};
 use tokio::runtime::Runtime;
 use tokio_stream::StreamExt;
-
-const BASIC_TRIGGER_SHORTCUT: &str = "CmdOrControl+Shift+.";
-const TRIGGER_WITH_CONTEXT_SHORTCUT: &str = "CmdOrControl+Shift+/";
-const USE_OLLAMA: bool = true;
+use crate::settings::SETTINGS;
 
 #[cfg(feature = "ocr")]
 mod ocr;
 
 mod generator;
+mod settings;
 
 fn make_tray() -> SystemTray {
     let quit = CustomMenuItem::new("quit".to_string(), "Quit");
-    let tray_menu = SystemTrayMenu::new().add_item(quit);
+    let load_settings = CustomMenuItem::new("load_settings".to_string(), "Load Settings");
+    let tray_menu = SystemTrayMenu::new()
+        .add_item(load_settings)
+        .add_native_item(SystemTrayMenuItem::Separator)
+        .add_item(quit);
     SystemTray::new().with_menu(tray_menu)
 }
 
@@ -124,6 +123,9 @@ fn main() {
 
     tauri::Builder::default()
         .setup(move |app| {
+            let _ = settings::ensure_local_data_dir(app.app_handle())
+                .expect("Failed to create local data dir");
+
             #[cfg(target_os = "macos")]
             {
                 app.set_activation_policy(ActivationPolicy::Accessory);
@@ -134,15 +136,17 @@ fn main() {
             }
 
             let trigger_flag_second_clone = trigger_flag_clone.clone();
+            let basic_shortcut = { SETTINGS.lock().unwrap().shortcuts.basic.clone() };
+            let with_context_shortcut = { SETTINGS.lock().unwrap().shortcuts.with_context.clone() };
 
             app.global_shortcut_manager()
-                .register(BASIC_TRIGGER_SHORTCUT, move || {
+                .register(&basic_shortcut, move || {
                     trigger_flag_second_clone.store(true, Ordering::SeqCst);
                 })
                 .expect("Failed to register global shortcut");
 
             app.global_shortcut_manager()
-                .register(TRIGGER_WITH_CONTEXT_SHORTCUT, move || {
+                .register(&with_context_shortcut, move || {
                     use_clipboard_flag_clone.store(true, Ordering::SeqCst);
                     trigger_flag_clone.store(true, Ordering::SeqCst);
                 })
@@ -152,10 +156,16 @@ fn main() {
         })
         .system_tray(make_tray())
         .on_system_tray_event({
-            move |_app, event| {
+            move |app, event| {
                 if let SystemTrayEvent::MenuItemClick { id, .. } = event {
-                    if id.as_str() == "quit" {
-                        std::process::exit(0)
+                    match id.as_str() {
+                        "quit" => std::process::exit(0),
+                        "load_settings" => {
+                            settings::load_settings(
+                                app.app_handle().clone()
+                            ).expect("Failed to load settings.");
+                        }
+                        _ => {}
                     }
                 }
             }
@@ -265,7 +275,8 @@ fn trigger_action(
     );
     println!("Context: {}", context);
 
-    let generator = if USE_OLLAMA {
+    let use_ollama = { SETTINGS.lock().unwrap().ollama.enabled };
+    let generator = if use_ollama {
         TextGeneratorType::OllamaGenerator
     } else {
         TextGeneratorType::ShellScriptGenerator

--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -1,0 +1,97 @@
+
+use serde::{Deserialize, Serialize};
+use std::{env, fs, path::Path};
+use std::collections::HashMap;
+use std::path::PathBuf;
+use std::sync::Mutex;
+use lazy_static::lazy_static;
+use tauri::{command, AppHandle};
+
+lazy_static! {
+    pub static ref SETTINGS: Mutex<Settings> = Mutex::new(Settings::default());
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct Ollama {
+    pub enabled: bool,
+    pub ollama_model: String,
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct Shortcuts {
+    pub basic: String,
+    pub with_context: String,
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct Settings {
+    pub environment: HashMap<String, String>,
+    pub ollama: Ollama,
+    pub custom_command: Vec<String>,
+    pub shortcuts: Shortcuts,
+}
+
+impl Default for Settings {
+    fn default() -> Self {
+        Self {
+            environment: HashMap::new(),
+            ollama: Ollama {
+                enabled: true,
+                ollama_model: "openhermes2.5-mistral".to_string(),
+            },
+            custom_command: ["bash", "/path/to/gpt.sh"].iter().map(|s| s.to_string()).collect(),
+            shortcuts: Shortcuts {
+                basic: "CmdOrControl+Shift+.".to_string(),
+                with_context: "CmdOrControl+Shift+/".to_string(),
+            },
+        }
+    }
+}
+
+pub fn save_current_settings(app_handle: AppHandle) -> Result<(), String> {
+    save_settings(app_handle, &*SETTINGS.lock().unwrap())?;
+    Ok(())
+}
+
+#[command]
+pub fn save_settings(app_handle: AppHandle, settings: &Settings) -> Result<(), String> {
+    let path = get_settings_path(app_handle)?;
+    let data = serde_json::to_string_pretty(settings).map_err(|e| e.to_string())?;
+    fs::write(path, data).map_err(|e| e.to_string())?;
+    Ok(())
+}
+
+#[command]
+pub fn load_settings(app_handle: AppHandle) -> Result<(), String> {
+    let path = get_settings_path(app_handle.clone())?;
+    let settings = if path.exists() {
+        let data = fs::read_to_string(path).map_err(|e| e.to_string())?;
+        serde_json::from_str(&data).map_err(|e| e.to_string())?
+    } else {
+        save_current_settings(app_handle)?;
+        Settings::default()
+    };
+    for (key, value) in settings.environment.iter() {
+        env::set_var(key, value);
+    }
+    *SETTINGS.lock().unwrap() = settings;
+    Ok(())
+}
+
+pub fn get_settings_path(app_handle: AppHandle) -> Result<PathBuf, String> {
+    let path = app_handle.path_resolver().app_local_data_dir().ok_or(
+        "Failed to get local data dir".to_string()
+    )?;
+    Ok(path.join(Path::new("settings.json")))
+}
+
+pub fn ensure_local_data_dir(app_handle: AppHandle) -> Result<String, ()> {
+    let local_data_dir = app_handle.path_resolver().app_local_data_dir();
+    if let Some(dir) = local_data_dir.clone() {
+        let path = dir.to_string_lossy().to_string();
+        if let Ok(()) = fs::create_dir_all(path.clone()) {
+            return Ok(path);
+        }
+    }
+    Err(())
+}

--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -24,10 +24,36 @@ pub struct Shortcuts {
 }
 
 #[derive(Serialize, Deserialize)]
+pub struct CustomCommand {
+    pub name: String,
+    pub command: Vec<String>,
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct CustomPrompt {
+    pub name: String,
+    pub prompt: String,
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct CustomPrompts {
+    pub basic_index: usize,
+    pub with_context_index: usize,
+    pub custom_prompts: Vec<CustomPrompt>,
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct CustomCommands {
+    pub index: usize,
+    pub custom_commands: Vec<CustomCommand>,
+}
+
+#[derive(Serialize, Deserialize)]
 pub struct Settings {
     pub environment: HashMap<String, String>,
     pub ollama: Ollama,
-    pub custom_command: Vec<String>,
+    pub custom_commands: CustomCommands,
+    pub custom_prompts: CustomPrompts,
     pub shortcuts: Shortcuts,
 }
 
@@ -39,7 +65,29 @@ impl Default for Settings {
                 enabled: true,
                 ollama_model: "openhermes2.5-mistral".to_string(),
             },
-            custom_command: ["bash", "/path/to/gpt.sh"].iter().map(|s| s.to_string()).collect(),
+            custom_commands: CustomCommands {
+                index: 0,
+                custom_commands: vec![
+                    CustomCommand {
+                        name: "gpt".to_string(),
+                        command: ["bash", "/path/to/gpt.sh"].iter().map(|s| s.to_string()).collect(),
+                    },
+                ],
+            },
+            custom_prompts: CustomPrompts {
+                basic_index: 0,
+                with_context_index: 1,
+                custom_prompts: vec![
+                    CustomPrompt {
+                        name: "default basic".to_string(),
+                        prompt: "{}".to_string(),
+                    },
+                    CustomPrompt {
+                        name: "default with context".to_string(),
+                        prompt: "I will ask you to do something. Below is some extra context to help do what I ask. --------- {} --------- Given the above context, please, {}. DO NOT OUTPUT ANYTHING ELSE.".to_string(),
+                    },
+                ],
+            },
             shortcuts: Shortcuts {
                 basic: "CmdOrControl+Shift+.".to_string(),
                 with_context: "CmdOrControl+Shift+/".to_string(),
@@ -49,7 +97,7 @@ impl Default for Settings {
 }
 
 pub fn save_current_settings(app_handle: AppHandle) -> Result<(), String> {
-    save_settings(app_handle, &*SETTINGS.lock().unwrap())?;
+    save_settings(app_handle, &SETTINGS.lock().unwrap())?;
     Ok(())
 }
 

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -11,6 +11,9 @@
   },
   "tauri": {
     "allowlist": {
+      "fs": {
+        "all": true
+      },
       "all": false,
       "shell": {
         "all": false,


### PR DESCRIPTION
Adds a settings.json file to configure instead of hardcoded vars.

Built to be compatible with a svelte front-end once that's built

Allows for this kind of setup:
```json
{
  "environment": {},
  "ollama": {
    "enabled": true,
    "ollama_model": "openhermes2.5-mistral"
  },
  "custom_commands": {
    "index": 0,
    "custom_commands": [
      {
        "name": "gpt",
        "command": [
          "bash",
          "/Users/jason/workspace/plock/scripts/gpt.sh"
        ]
      }
    ]
  },
  "custom_prompts": {
    "basic_index": 0,
    "with_context_index": 1,
    "custom_prompts": [
      {
        "name": "default basic",
        "prompt": "Say hello, then {}"
      },
      {
        "name": "default with context",
        "prompt": "I will ask you to do something. Below is some extra context to help do what I ask. --------- {} --------- Given the above context, please, {}. DO NOT OUTPUT ANYTHING ELSE."
      }
    ]
  },
  "shortcuts": {
    "basic": "CmdOrControl+Shift+.",
    "with_context": "CmdOrControl+Shift+/"
  }
}

```

Why are there multiple prompts and commands?
Future-proofing, so we can select them from a list.

Can be dynamically loaded at any time:
<img width="174" alt="image" src="https://github.com/jasonjmcghee/plock/assets/1522149/8a1f2aa4-5f40-4d38-8abc-462c866a76ea">
