### PR TITLE
Fix get_context function to use mutable iterator in main.rs

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -260,18 +260,18 @@ fn get_context(
         }
     };
 
-    let pieces = with_context_prompt.split("{}");
+    let mut pieces = with_context_prompt.split("{}");
     let mut final_prompt = "".to_string();
     // Before {}
-    final_prompt.push_str(pieces.clone().next().unwrap());
+    final_prompt.push_str(pieces.next().unwrap());
     // Replace first {} with context
     final_prompt.push_str(&context);
     // After first {}, before second {}
-    final_prompt.push_str(pieces.clone().next().unwrap());
+    final_prompt.push_str(pieces.next().unwrap());
     // Replace second {} with user_prompt
     final_prompt.push_str(&user_prompt);
     // After second {}
-    final_prompt.push_str(pieces.clone().next().unwrap());
+    final_prompt.push_str(pieces.next().unwrap());
     final_prompt
 }
 


### PR DESCRIPTION
This pull request fixes the get_context function in main.rs to use a mutable iterator. Previously, the function used an immutable iterator, which caused issues when trying to replace certain parts of the prompt string. This change ensures that the function correctly replaces the desired parts of the prompt string and improves the overall functionality of the code.