### PR TITLE
Fix issue with clipboard content retrieval

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -102,7 +102,7 @@ fn main() {
                         .lock()
                         .unwrap()
                         .get_text()
-                        .expect("Failed to get clipboard contents.")
+                        .unwrap_or_else(|_| String::new())
                 };
                 let cloned_contents = original_clipboard_contents.clone();
                 {


### PR DESCRIPTION
This pull request fixes an issue where the program would crash if the content of the clipboard was not a text object. The fix ensures that an empty string is returned in such cases.