### PR TITLE
[plock-10]: Attempted fix for dropped chars

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "build": {
-    "beforeBuildCommand": "mkdir -p dist && npm run build",
-    "beforeDevCommand": "mkdir -p dist && npm run dev",
+    "beforeBuildCommand": "mkdir -p dist ; npm run build",
+    "beforeDevCommand": "mkdir -p dist ; npm run dev",
     "devPath": "../dist",
     "distDir": "../dist"
   },


### PR DESCRIPTION
(quick fix at lunch...)

@kengoodridge @pentamassiv

I managed to get it working with this approach. Note the `19` character chunks... Did _not_ work with `20`. 🤯 

Also the newline fix... @kengoodridge, also seemed necessary - I added a space before every newline, which fixed it for me, but checking if a `text` chunk started with one was not enough.

We'll figure out the right way to get you credit @kengoodridge - maybe I'll open my PR as a modification of yours...

@pentamassiv - does this fix make any kind of sense to you?

I tried sleeps as you suggested to no avail, I also noticed the 2ms sleep was _outside_ of the chunked loop, which seemed wrong as a HID signal was being sent, potentially with no delay.

---

FWIW the easiest way to reproduce this issue is to `cat` a large text file and use `diff` command.